### PR TITLE
Changed shouldPushState to provide the full *parsed* state 

### DIFF
--- a/src/withUrlState.ts
+++ b/src/withUrlState.ts
@@ -124,7 +124,7 @@ export const withUrlState =
 
           config &&
           config.shouldPushState &&
-          config.shouldPushState(this.props, newState, parse(this.state.previousSearch))
+          config.shouldPushState(this.props, parse(search), parse(this.state.previousSearch))
             ? history.push(nextLocation)
             : history.replace(nextLocation)
 


### PR DESCRIPTION
As per [the issue here](https://github.com/Dean177/with-url-state/issues/97) I've changed `shouldPushState` to allow comparison of the full parsed state with the current parsed state.
 I've also added a test case to this as there is a potential subtlety about how you implement it that would be easy to cause a regression on. The test case is hard to word but hopefully it makes sense. Let me know if not