### PR TITLE
Changed dependency from 'query-string' to 'qs' due to the package pro…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "Dean Merchant",
+  "contributors": ["Matt Hawes <hawes.info@gmail.com> (https://github.com/MGHawes)"],
   "name": "with-url-state",
   "version": "2.0.0-beta.3",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.0-beta.3",
   "dependencies": {
     "@types/history": "^4.6.2",
-    "query-string": "6.0.0"
+    "qs": "6.5.1"
   },
   "peerDependencies": {
     "history": "4.6.x || 4.7.x",
@@ -26,7 +26,7 @@
     "history": "4.7.2",
     "jest": "22.4.0",
     "jsdom": "11.7.0",
-    "qs": "6.5.1",
+    "query-string": "6.0.0",
     "react": "16.3.1",
     "react-dom": "16.3.1",
     "react-test-renderer": "16.3.1",

--- a/src/withUrlState.ts
+++ b/src/withUrlState.ts
@@ -6,7 +6,7 @@ import {
   Search,
   UnregisterCallback,
 } from 'history'
-import * as queryString from 'query-string'
+import * as qs from 'qs'
 import { Component, ComponentClass, ComponentType, createElement } from 'react'
 
 type Decorator<Props, EnhancedProps> = (component: ComponentType<EnhancedProps>) => ComponentType<Props>
@@ -70,11 +70,11 @@ export const withUrlState =
 
     const parse: Parse<T> = config && config.serialisation && config.serialisation.parse
       ? config.serialisation.parse
-      : queryString.parse
+      : (queryString: string) => qs.parse(queryString, { ignoreQueryPrefix: true })
 
     const stringify: Stringify<T> = config && config.serialisation && config.serialisation.stringify
       ? config.serialisation.stringify
-      : queryString.stringify
+      : (state: Partial<T>) => qs.stringify(state, { addQueryPrefix: true })
 
     return (WrappedComponent: ComponentType<OP & UrlStateProps<T>>): ComponentClass<OP> =>
       class WithUrlStateWrapper extends Component<OP, InternalState<T>> {


### PR DESCRIPTION
Changed dependency from 'query-string' to 'qs' due to the package providing un-transpiled ES6 code